### PR TITLE
feat: capture marketplace IDs in price data pipeline

### DIFF
--- a/app/deck/[id]/DeckContent.tsx
+++ b/app/deck/[id]/DeckContent.tsx
@@ -15,6 +15,8 @@ import type { PreconDeck, CardWithPrice } from '@/types';
 interface FormattedCard extends CardWithPrice {
   id: string;
   isCommander?: boolean;
+  tcgplayerId?: number;
+  cardmarketId?: number;
 }
 
 export default function DeckContent({ deckId }: { deckId: string }) {
@@ -48,6 +50,8 @@ export default function DeckContent({ deckId }: { deckId: string }) {
           price: card.price,
           total: card.total,
           isCommander: card.isCommander,
+          tcgplayerId: card.tcgplayerId,
+          cardmarketId: card.cardmarketId,
         }));
         const cardsWithoutPrice = formattedCards.filter(c => c.price === 0 || c.price === null);
         setExcludedCount(cardsWithoutPrice.length);
@@ -83,6 +87,8 @@ export default function DeckContent({ deckId }: { deckId: string }) {
           price: card.price,
           total: card.total,
           isCommander: card.isCommander,
+          tcgplayerId: card.tcgplayerId,
+          cardmarketId: card.cardmarketId,
         }));
         const cardsWithoutPrice = formattedCards.filter(c => c.price === 0 || c.price === null);
         setExcludedCount(cardsWithoutPrice.length);

--- a/lib/scryfall.ts
+++ b/lib/scryfall.ts
@@ -141,6 +141,8 @@ export const getStaticDeckPrices = async (deckId: string): Promise<StaticDeckPri
       price: card.usd ? parseFloat(card.usd) : 0,
       total: card.usd ? parseFloat(card.usd) * card.quantity : 0,
       isCommander: card.isCommander,
+      tcgplayerId: card.tcgplayerId,
+      cardmarketId: card.cardmarketId,
     })),
     topCards: deckData.cards
       .filter(c => c.usd)
@@ -151,6 +153,8 @@ export const getStaticDeckPrices = async (deckId: string): Promise<StaticDeckPri
         price: card.usd ? parseFloat(card.usd) : 0,
         total: card.usd ? parseFloat(card.usd) * card.quantity : 0,
         isCommander: card.isCommander,
+        tcgplayerId: card.tcgplayerId,
+        cardmarketId: card.cardmarketId,
       })),
   };
 };

--- a/scripts/update-prices.ts
+++ b/scripts/update-prices.ts
@@ -23,6 +23,13 @@ interface BulkCard {
   collector_number: string;
   promo?: boolean;
   prices?: CardPrices;
+  tcgplayer_id?: number;
+  cardmarket_id?: number;
+  purchase_uris?: {
+    tcgplayer?: string;
+    cardmarket?: string;
+    cardhoarder?: string;
+  };
 }
 
 interface ComputedCardPrice {
@@ -30,6 +37,8 @@ interface ComputedCardPrice {
   quantity: number;
   usd: string | null;
   isCommander?: boolean;
+  tcgplayerId?: number;
+  cardmarketId?: number;
 }
 
 interface ComputedDeckPrices {
@@ -130,6 +139,14 @@ interface CardVersion {
   collectorNumber: string;
   isPromo: boolean;
   isFoilOnly: boolean;
+  tcgplayerId?: number;
+  cardmarketId?: number;
+}
+
+interface PriceLookupEntry {
+  priceStr: string | null;
+  tcgplayerId?: number;
+  cardmarketId?: number;
 }
 
 function isSerializedCollectorNumber(cn: string): boolean {
@@ -139,7 +156,7 @@ function isSerializedCollectorNumber(cn: string): boolean {
 function buildSetAwarePriceLookup(
   allCards: BulkCard[],
   neededCardSets: Map<string, Set<string>>
-): Map<string, string | null> {
+): Map<string, PriceLookupEntry> {
   console.log('Building set-aware price lookup (selecting cheapest versions)...');
 
   const cardVersions = new Map<string, CardVersion[]>();
@@ -169,10 +186,12 @@ function buildSetAwarePriceLookup(
       collectorNumber: card.collector_number,
       isPromo: card.promo === true,
       isFoilOnly: usd === null && usdFoil !== null,
+      tcgplayerId: card.tcgplayer_id,
+      cardmarketId: card.cardmarket_id,
     });
   }
 
-  const lookup = new Map<string, string | null>();
+  const lookup = new Map<string, PriceLookupEntry>();
   let serializedSkipped = 0;
 
   for (const [setKey, versions] of cardVersions) {
@@ -193,7 +212,12 @@ function buildSetAwarePriceLookup(
     });
 
     if (candidates.length > 0) {
-      lookup.set(setKey, candidates[0].priceStr);
+      const best = candidates[0];
+      lookup.set(setKey, {
+        priceStr: best.priceStr,
+        tcgplayerId: best.tcgplayerId,
+        cardmarketId: best.cardmarketId,
+      });
     }
   }
 
@@ -205,7 +229,7 @@ function buildSetAwarePriceLookup(
 function computeDeckPrices(
   decklists: Decklists,
   deckSetMap: DeckSetMap,
-  priceLookup: Map<string, string | null>
+  priceLookup: Map<string, PriceLookupEntry>
 ): Record<string, ComputedDeckPrices> {
   console.log('Computing deck prices...');
   const decks: Record<string, ComputedDeckPrices> = {};
@@ -219,7 +243,8 @@ function computeDeckPrices(
 
     for (const card of cards) {
       const setKey = `${card.name}|${setCode}`;
-      const priceStr = priceLookup.get(setKey) ?? null;
+      const lookupEntry = priceLookup.get(setKey);
+      const priceStr = lookupEntry?.priceStr ?? null;
 
       if (!priceStr) {
         missingPrices++;
@@ -233,6 +258,8 @@ function computeDeckPrices(
         quantity: card.quantity,
         usd: priceStr,
         isCommander: card.isCommander,
+        tcgplayerId: lookupEntry?.tcgplayerId,
+        cardmarketId: lookupEntry?.cardmarketId,
       });
 
       totalValue += lineTotal;


### PR DESCRIPTION
## Summary
- Update `update-prices.ts` to extract `tcgplayer_id` and `cardmarket_id` from Scryfall bulk data
- Add `PriceLookupEntry` interface to track price + marketplace IDs together
- Update `lib/scryfall.ts` to pass marketplace IDs through `getStaticDeckPrices`
- Update `DeckContent` to include marketplace IDs when formatting cards for display

## Test Plan
- [x] Build passes
- [x] Lint passes
- [ ] Run `npx tsx scripts/update-prices.ts` to verify IDs captured
- [ ] Verify price data flows through to CardPriceRow component

**Depends on:** #3

🤖 Generated with [Claude Code](https://claude.ai/code)