### PR TITLE
fix: pin Bun version in CI and migrate Playwright to Bun

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: oven-sh/setup-bun@v2
       with:
-        node-version: lts/*
+        bun-version: "1.3.6"
     - name: Install dependencies
-      run: npm install -g pnpm && pnpm install
+      run: bun install --frozen-lockfile
     - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
+      run: bunx playwright install --with-deps
     - name: Run Playwright tests
-      run: pnpm exec playwright test
+      run: bunx playwright test
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/update-prices.yml
+++ b/.github/workflows/update-prices.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Pin `bun-version: "1.3.6"` in `update-prices.yml` to prevent lockfile drift when CI installs a newer Bun release
- Migrate `playwright.yml` from pnpm/Node to Bun for consistency (pnpm-lock.yaml was already removed)

## Test plan

- [ ] Playwright CI passes on this PR (validates Bun migration)
- [ ] After merge, trigger `gh workflow run update-prices.yml` to validate pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)