### PR TITLE
feat: add size limit and field validation to CSP report endpoint

### DIFF
--- a/app/api/csp-report/route.ts
+++ b/app/api/csp-report/route.ts
@@ -1,11 +1,36 @@
 import { NextResponse } from 'next/server';
 
+const MAX_BODY_SIZE = 10 * 1024; // 10KB
+
 export async function POST(request: Request) {
+  let text: string;
   try {
-    const body = await request.json();
-    console.warn('[CSP Violation]', JSON.stringify(body['csp-report'] || body, null, 2));
+    text = await request.text();
   } catch {
-    // Malformed report body - ignore
+    return new NextResponse(null, { status: 400 });
   }
+
+  if (text.length > MAX_BODY_SIZE) {
+    return new NextResponse(null, { status: 413 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return new NextResponse(null, { status: 400 });
+  }
+
+  const report = body['csp-report'] as Record<string, unknown> | undefined;
+  if (
+    !report ||
+    typeof report !== 'object' ||
+    !report['document-uri'] ||
+    !report['violated-directive']
+  ) {
+    return new NextResponse(null, { status: 400 });
+  }
+
+  console.warn('[CSP Violation]', JSON.stringify(report, null, 2));
   return new NextResponse(null, { status: 204 });
 }


### PR DESCRIPTION
## Summary
- Adds 10KB body size limit (returns 413 if exceeded)
- Validates JSON parsing (returns 400 for malformed bodies)
- Validates required CSP report fields (`document-uri`, `violated-directive` must exist)
- Returns 400 for missing/invalid fields, 204 for valid reports

Closes #11

## Test plan
- [ ] Send oversized payload (>10KB) — verify 413 response
- [ ] Send malformed JSON — verify 400 response
- [ ] Send valid JSON missing `csp-report` key — verify 400 response
- [ ] Send `csp-report` missing required fields — verify 400 response
- [ ] Send valid CSP report — verify 204 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)