### PR TITLE
feat: add client-side size validation to contact form

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -19,6 +19,17 @@ export default function ContactForm() {
     const form = e.currentTarget;
     const formData = new FormData(form);
 
+    const encoder = new TextEncoder();
+    let totalSize = 0;
+    for (const [key, value] of formData.entries()) {
+      totalSize += encoder.encode(key).length + encoder.encode(String(value)).length;
+    }
+    if (totalSize > 5 * 1024) {
+      setStatus('error');
+      setErrorMessage('Your message is too large. Please shorten your input and try again.');
+      return;
+    }
+
     if (!formspreeId) {
       setStatus('error');
       setErrorMessage('Contact form is not configured. Please email us directly.');


### PR DESCRIPTION
## Summary
- Adds 5KB client-side size limit on contact form submissions
- Uses `TextEncoder` for byte-accurate size measurement of all form fields
- Shows descriptive error message if payload exceeds limit, aborting submission

Closes #12

## Test plan
- [ ] Fill form with normal content — verify submission works as before
- [ ] Paste >5KB of text into message field — verify error message appears and submission is blocked
- [ ] Verify error clears when retrying with shorter content

🤖 Generated with [Claude Code](https://claude.com/claude-code)