### PR TITLE
feat: add X-Permitted-Cross-Domain-Policies header

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -97,6 +97,7 @@ export function middleware(request: NextRequest) {
   });
 
   response.headers.set('Content-Security-Policy', generateCspHeader(nonce));
+  response.headers.set('X-Permitted-Cross-Domain-Policies', 'none');
   response.headers.set('Report-To', JSON.stringify({
     group: 'csp-endpoint',
     max_age: 86400,


### PR DESCRIPTION
## Summary
- Adds `X-Permitted-Cross-Domain-Policies: none` to middleware response headers
- Prevents Flash/Acrobat from loading cross-domain policy files from this origin

Closes #14

## Test plan
- [ ] Verify header present in response: `curl -I localhost:3000 | grep -i cross-domain`
- [ ] Confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)