### PR TITLE
feat: add Suspense boundaries and route-level error boundaries

### DIFF
--- a/app/compare/error.tsx
+++ b/app/compare/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react';
+
+export default function CompareError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center px-6">
+      <div className="text-center max-w-md">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-500/20 mb-6">
+          <AlertCircle className="w-8 h-8 text-red-400" />
+        </div>
+        <h1 className="text-2xl font-bold text-white mb-2">Failed to load comparison data</h1>
+        <p className="text-slate-400 mb-6">
+          Price data could not be fetched. Please try again.
+        </p>
+        <div className="flex gap-4 justify-center">
+          <button
+            onClick={reset}
+            className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg transition-colors"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-lg transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/compare/loading.tsx
+++ b/app/compare/loading.tsx
@@ -1,0 +1,12 @@
+import { Loader2 } from 'lucide-react';
+
+export default function CompareLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="w-10 h-10 text-purple-400 animate-spin mx-auto mb-4" />
+        <p className="text-slate-400">Loading comparison data...</p>
+      </div>
+    </div>
+  );
+}

--- a/app/deck/[id]/error.tsx
+++ b/app/deck/[id]/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { AlertCircle, ArrowLeft, RefreshCw } from 'lucide-react';
+
+export default function DeckError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center px-6">
+      <div className="text-center max-w-md">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-500/20 mb-6">
+          <AlertCircle className="w-8 h-8 text-red-400" />
+        </div>
+        <h1 className="text-2xl font-bold text-white mb-2">Failed to load deck</h1>
+        <p className="text-slate-400 mb-6">
+          Deck data could not be loaded. Please try again.
+        </p>
+        <div className="flex gap-4 justify-center">
+          <button
+            onClick={reset}
+            className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg transition-colors"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-lg transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/deck/[id]/loading.tsx
+++ b/app/deck/[id]/loading.tsx
@@ -1,0 +1,12 @@
+import { Loader2 } from 'lucide-react';
+
+export default function DeckLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="w-10 h-10 text-purple-400 animate-spin mx-auto mb-4" />
+        <p className="text-slate-400">Loading deck data...</p>
+      </div>
+    </div>
+  );
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,12 @@
+import { Loader2 } from 'lucide-react';
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
+      <div className="text-center">
+        <Loader2 className="w-10 h-10 text-purple-400 animate-spin mx-auto mb-4" />
+        <p className="text-slate-400">Loading...</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `loading.tsx` (Suspense fallback UI) for `/`, `/compare`, and `/deck/[id]` routes
- Adds route-specific `error.tsx` for `/compare` and `/deck/[id]` with contextual messages and retry/home buttons
- Provides graceful degradation when async data loading fails

Closes #16

## Test plan
- [ ] Navigate to `/compare` — verify loading spinner shows briefly before content
- [ ] Navigate to `/deck/[id]` — verify loading spinner shows briefly
- [ ] Simulate error in compare page — verify route-specific error UI with retry button
- [ ] Simulate error in deck page — verify route-specific error UI with retry button

🤖 Generated with [Claude Code](https://claude.com/claude-code)