### PR TITLE
feat: deduplicate concurrent static file fetches

### DIFF
--- a/lib/scryfall.ts
+++ b/lib/scryfall.ts
@@ -134,14 +134,16 @@ let staticPricesCache: StaticPricesData | null = null;
 export const loadStaticPrices = async (): Promise<StaticPricesData | null> => {
   if (staticPricesCache) return staticPricesCache;
 
-  try {
-    const response = await fetchWithTimeout('/data/prices.json');
-    if (!response.ok) return null;
-    staticPricesCache = await response.json() as StaticPricesData;
-    return staticPricesCache;
-  } catch {
-    return null;
-  }
+  return deduplicatedFetch<StaticPricesData | null>('static:prices.json', async () => {
+    try {
+      const response = await fetchWithTimeout('/data/prices.json');
+      if (!response.ok) return null;
+      staticPricesCache = await response.json() as StaticPricesData;
+      return staticPricesCache;
+    } catch {
+      return null;
+    }
+  });
 };
 
 export const getStaticSetPrices = async (setCode: string): Promise<StaticCardData[] | null> => {
@@ -457,14 +459,16 @@ let lowestListingsCache: LowestListingsData | null = null;
 export const loadLowestListings = async (): Promise<LowestListingsData | null> => {
   if (lowestListingsCache) return lowestListingsCache;
 
-  try {
-    const response = await fetchWithTimeout('/data/lowest-listings.json');
-    if (!response.ok) return null;
-    lowestListingsCache = await response.json() as LowestListingsData;
-    return lowestListingsCache;
-  } catch {
-    return null;
-  }
+  return deduplicatedFetch<LowestListingsData | null>('static:lowest-listings.json', async () => {
+    try {
+      const response = await fetchWithTimeout('/data/lowest-listings.json');
+      if (!response.ok) return null;
+      lowestListingsCache = await response.json() as LowestListingsData;
+      return lowestListingsCache;
+    } catch {
+      return null;
+    }
+  });
 };
 
 export const getLowestListingForCard = async (cardName: string): Promise<number | null> => {


### PR DESCRIPTION
## Summary
- Wraps `loadStaticPrices` (`/data/prices.json`) with `deduplicatedFetch`
- Wraps `loadLowestListings` (`/data/lowest-listings.json`) with `deduplicatedFetch`
- Prevents multiple concurrent requests for the same static resource when called simultaneously

Closes #18

## Test plan
- [ ] Verify build passes
- [ ] Load home page — confirm prices load correctly (single network request for prices.json)
- [ ] Rapidly navigate between decks — confirm no duplicate static fetches in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)