### PR TITLE
feat: warn on missing optional env vars at build time

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,16 @@
+const optionalEnvVars = [
+  { key: 'NEXT_PUBLIC_ADSENSE_CLIENT_ID', feature: 'Google AdSense ads' },
+  { key: 'NEXT_PUBLIC_FORMSPREE_ID', feature: 'Contact form submissions' },
+  { key: 'JUSTTCG_API_KEY', feature: 'JustTCG price source' },
+];
+
+const missing = optionalEnvVars.filter(v => !process.env[v.key]);
+if (missing.length > 0) {
+  console.warn('\n⚠ Optional environment variables not set:');
+  missing.forEach(v => console.warn(`  - ${v.key}: ${v.feature} disabled`));
+  console.warn('');
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {


### PR DESCRIPTION
## Summary
- Checks for optional env vars at Next.js config load time
- Logs warnings listing which features are disabled when vars are missing
- Covers: `NEXT_PUBLIC_ADSENSE_CLIENT_ID`, `NEXT_PUBLIC_FORMSPREE_ID`, `JUSTTCG_API_KEY`

Closes #19

## Test plan
- [ ] Run `bun build` without env vars — verify warnings appear in build output
- [ ] Set all env vars — verify no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)