### PR TITLE
feat: handle localStorage quota errors with user feedback

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Trash2, RefreshCw, Loader2 } from 'lucide-react';
 import DeckComparisonTable from '@/components/DeckComparisonTable';
+import { useToast } from '@/components/ui/ToastProvider';
 import { PRECON_DATABASE, getDeckCards } from '@/lib/precons';
 import { loadStaticPrices, fetchDeckPrices } from '@/lib/scryfall';
 import { getCachedPrice, setCachedPrice, clearCache, formatStaticPriceAge } from '@/lib/priceCache';
@@ -16,6 +17,7 @@ interface RefreshProgress {
 }
 
 export default function ComparePage() {
+  const { toast } = useToast();
   const [priceData, setPriceData] = useState<Record<string, CachedPriceData>>({});
   const [loadingDeck, setLoadingDeck] = useState<string | null>(null);
   const [refreshingAll, setRefreshingAll] = useState(false);
@@ -91,7 +93,9 @@ export default function ComparePage() {
         cardCount: priceResult.cardCount,
       };
 
-      setCachedPrice(deck.id, data);
+      if (!setCachedPrice(deck.id, data)) {
+        toast('Storage full — price cache unavailable', 'error');
+      }
 
       setPriceData(prev => ({
         ...prev,

--- a/components/CookieConsent.tsx
+++ b/components/CookieConsent.tsx
@@ -38,13 +38,17 @@ export default function CookieConsent() {
   }, []);
 
   const handleAccept = useCallback(() => {
-    localStorage.setItem(CONSENT_KEY, 'accepted');
+    try {
+      localStorage.setItem(CONSENT_KEY, 'accepted');
+    } catch { /* storage unavailable */ }
     setShowBanner(false);
     updateGoogleConsent(true);
   }, []);
 
   const handleReject = useCallback(() => {
-    localStorage.setItem(CONSENT_KEY, 'rejected');
+    try {
+      localStorage.setItem(CONSENT_KEY, 'rejected');
+    } catch { /* storage unavailable */ }
     setShowBanner(false);
     updateGoogleConsent(false);
   }, []);

--- a/lib/priceCache.ts
+++ b/lib/priceCache.ts
@@ -18,8 +18,8 @@ export const getCachedPrice = (deckId: string): CachedPriceData | null => {
   }
 };
 
-export const setCachedPrice = (deckId: string, data: Omit<CachedPriceData, 'fetchedAt'>): void => {
-  if (typeof window === 'undefined') return;
+export const setCachedPrice = (deckId: string, data: Omit<CachedPriceData, 'fetchedAt'>): boolean => {
+  if (typeof window === 'undefined') return false;
 
   const key = CACHE_PREFIX + deckId;
   const cacheData: CachedPriceData = {
@@ -29,8 +29,9 @@ export const setCachedPrice = (deckId: string, data: Omit<CachedPriceData, 'fetc
 
   try {
     localStorage.setItem(key, JSON.stringify(cacheData));
+    return true;
   } catch {
-    // Quota exceeded or private browsing - silently fail
+    return false;
   }
 };
 


### PR DESCRIPTION
## Summary
- `setCachedPrice` now returns `boolean` — `false` on quota/storage errors
- Compare page shows toast notification when cache write fails
- `CookieConsent` wraps `localStorage.setItem` in try/catch for graceful degradation

Closes #20

## Test plan
- [ ] Verify build passes
- [ ] Simulate quota exceeded (fill localStorage) — verify toast appears on compare page
- [ ] In private browsing mode — verify cookie consent still works (dismisses banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)