### PR TITLE
feat: enforce 5s auto-dismiss on all non-loading toasts

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -33,13 +33,16 @@ const iconStyles = {
   loading: 'text-purple-400 animate-spin',
 };
 
+const AUTO_DISMISS_MS = 5000;
 const LOADING_MAX_DURATION = 30000;
 
-export function Toast({ message, type, duration = 4000, onClose }: ToastProps) {
+export function Toast({ message, type, duration, onClose }: ToastProps) {
   const Icon = icons[type];
 
   useEffect(() => {
-    const timeout = type === 'loading' ? LOADING_MAX_DURATION : duration;
+    const timeout = type === 'loading'
+      ? LOADING_MAX_DURATION
+      : Math.min(duration ?? AUTO_DISMISS_MS, LOADING_MAX_DURATION);
     const timer = setTimeout(onClose, timeout);
     return () => clearTimeout(timer);
   }, [duration, onClose, type]);


### PR DESCRIPTION
## Summary
- Default auto-dismiss duration changed from 4s to 5s
- Custom durations capped at 30s to prevent indefinite display
- Loading toasts unchanged (30s max)

Closes #21

## Test plan
- [ ] Trigger a toast — verify it auto-dismisses after ~5s
- [ ] Verify loading toasts still show for their full duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)