### PR TITLE
feat: show toast notification on card search errors

### DIFF
--- a/components/CardSearch.tsx
+++ b/components/CardSearch.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { Search, Plus, X } from 'lucide-react';
 import { searchCards, getCardImage, getCardPrice } from '@/lib/scryfall';
 import { formatCurrency } from '@/lib/calculations';
+import { useToast } from '@/components/ui/ToastProvider';
 import type { ScryfallCard } from '@/types';
 
 interface CardSearchProps {
@@ -12,6 +13,7 @@ interface CardSearchProps {
 }
 
 export default function CardSearch({ onAddCard }: CardSearchProps) {
+  const { toast } = useToast();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<ScryfallCard[]>([]);
   const [loading, setLoading] = useState(false);
@@ -28,6 +30,7 @@ export default function CardSearch({ onAddCard }: CardSearchProps) {
     } catch {
       setError('Failed to search cards');
       setResults([]);
+      toast('Card search failed — please try again', 'error');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Adds `useToast` hook to CardSearch component
- Shows error toast when card search API call fails
- Keeps existing inline error message for context within the component

Closes #22

## Test plan
- [ ] Search for a valid card — verify normal results
- [ ] Simulate network error (disable network) — verify toast appears with error message
- [ ] Verify inline error text also shows below the search input

🤖 Generated with [Claude Code](https://claude.com/claude-code)