### PR TITLE
feat: implement focus trap in modals

### DIFF
--- a/components/AddDeckModal.tsx
+++ b/components/AddDeckModal.tsx
@@ -45,6 +45,7 @@ export default function AddDeckModal({ isOpen, onClose, onAdd }: AddDeckModalPro
   };
 
   const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -69,10 +70,16 @@ export default function AddDeckModal({ isOpen, onClose, onAdd }: AddDeckModalPro
 
   useEffect(() => {
     if (!isOpen) return;
+    triggerRef.current = document.activeElement;
     document.addEventListener('keydown', handleKeyDown);
     const firstInput = dialogRef.current?.querySelector<HTMLElement>('input');
     firstInput?.focus();
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
   }, [isOpen, handleKeyDown]);
 
   if (!isOpen) return null;
@@ -90,6 +97,7 @@ export default function AddDeckModal({ isOpen, onClose, onAdd }: AddDeckModalPro
           <h2 id="add-deck-title" className="text-lg font-semibold text-white">Add Custom Deck</h2>
           <button
             onClick={onClose}
+            aria-label="Close dialog"
             className="text-slate-400 hover:text-white"
           >
             <X className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- Restore focus to the trigger element (e.g., "Add Custom Deck" button) when modal closes
- Add `aria-label` to the icon-only close button

Note: Focus trapping (Tab cycling), Escape key handling, and initial focus on first input were already implemented.

## Test plan
- [ ] Open modal, close via Escape — focus returns to "Add Custom Deck" button
- [ ] Open modal, close via Cancel button — focus returns to trigger
- [ ] Open modal, submit form — focus returns to trigger
- [ ] Tab cycles within modal without escaping to background

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)