### PR TITLE
feat: add schema validation to script input files

### DIFF
--- a/scripts/fetch-lowest-listings.ts
+++ b/scripts/fetch-lowest-listings.ts
@@ -8,6 +8,7 @@ import {
   scrapeLowestListing,
   type LowestListingResult,
 } from '../lib/tcgplayer-scraper';
+import { validateDecklists, validatePriceData, validateLowestListings } from './validate-input';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -79,14 +80,16 @@ function loadWatchlist(): string[] {
 
 function loadDecklists(): Decklists {
   console.log('Loading decklists...');
-  const data = JSON.parse(readFileSync(DECKLISTS_PATH, 'utf-8')) as Decklists;
+  const raw = JSON.parse(readFileSync(DECKLISTS_PATH, 'utf-8'));
+  const data = validateDecklists(raw);
   console.log(`Loaded ${Object.keys(data).length} decks`);
   return data;
 }
 
 function loadPrices(): PriceData {
   console.log('Loading prices...');
-  const data = JSON.parse(readFileSync(PRICES_PATH, 'utf-8')) as PriceData;
+  const raw = JSON.parse(readFileSync(PRICES_PATH, 'utf-8'));
+  const data = validatePriceData(raw) as PriceData;
   console.log(`Loaded prices for ${Object.keys(data.decks).length} decks`);
   return data;
 }
@@ -180,10 +183,12 @@ function loadExistingListings(): LowestListingsData | null {
   if (!existsSync(OUTPUT_PATH)) return null;
 
   try {
-    const data = JSON.parse(readFileSync(OUTPUT_PATH, 'utf-8')) as LowestListingsData;
+    const raw = JSON.parse(readFileSync(OUTPUT_PATH, 'utf-8'));
+    const data = validateLowestListings(raw);
     console.log(`Loaded existing listings for ${Object.keys(data.cards).length} cards`);
     return data;
-  } catch {
+  } catch (error) {
+    console.warn(`Failed to load existing listings: ${(error as Error).message}`);
     return null;
   }
 }

--- a/scripts/update-prices.ts
+++ b/scripts/update-prices.ts
@@ -13,6 +13,7 @@ import { writeFileSync, readFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import type { Decklists, CardPrices } from '../types';
+import { validateDecklists } from './validate-input';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -90,7 +91,8 @@ async function fetchWithRetry(url: string, maxRetries: number = 5): Promise<Resp
 
 function loadDecklists(): Decklists {
   console.log('Loading decklists...');
-  const data = JSON.parse(readFileSync(DECKLISTS_PATH, 'utf-8')) as Decklists;
+  const raw = JSON.parse(readFileSync(DECKLISTS_PATH, 'utf-8'));
+  const data = validateDecklists(raw);
   const deckCount = Object.keys(data).length;
   console.log(`Loaded ${deckCount} decks`);
   return data;

--- a/scripts/validate-input.ts
+++ b/scripts/validate-input.ts
@@ -1,0 +1,90 @@
+import type { Decklists, LowestListingsData } from '../types';
+
+export function validateDecklists(data: unknown): Decklists {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('Invalid decklists: expected an object');
+  }
+
+  const obj = data as Record<string, unknown>;
+  for (const [deckId, cards] of Object.entries(obj)) {
+    if (!Array.isArray(cards)) {
+      throw new Error(`Invalid decklists: deck "${deckId}" is not an array`);
+    }
+    for (let i = 0; i < cards.length; i++) {
+      const card = cards[i];
+      if (typeof card !== 'object' || card === null) {
+        throw new Error(`Invalid decklists: deck "${deckId}" card[${i}] is not an object`);
+      }
+      if (typeof card.name !== 'string' || card.name.length === 0) {
+        throw new Error(`Invalid decklists: deck "${deckId}" card[${i}] missing name`);
+      }
+      if (typeof card.quantity !== 'number' || card.quantity < 1) {
+        throw new Error(`Invalid decklists: deck "${deckId}" card "${card.name}" has invalid quantity`);
+      }
+    }
+  }
+
+  return obj as unknown as Decklists;
+}
+
+interface PriceDataShape {
+  updatedAt: string;
+  decks: Record<string, {
+    totalValue: number;
+    cardCount: number;
+    cards: Array<{
+      name: string;
+      quantity: number;
+      usd?: string | null;
+    }>;
+  }>;
+}
+
+export function validatePriceData(data: unknown): PriceDataShape {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('Invalid price data: expected an object');
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.updatedAt !== 'string') {
+    throw new Error('Invalid price data: missing "updatedAt" string');
+  }
+  if (typeof obj.decks !== 'object' || obj.decks === null || Array.isArray(obj.decks)) {
+    throw new Error('Invalid price data: missing "decks" object');
+  }
+
+  const decks = obj.decks as Record<string, unknown>;
+  for (const [deckId, deck] of Object.entries(decks)) {
+    if (typeof deck !== 'object' || deck === null) {
+      throw new Error(`Invalid price data: deck "${deckId}" is not an object`);
+    }
+    const d = deck as Record<string, unknown>;
+    if (typeof d.totalValue !== 'number') {
+      throw new Error(`Invalid price data: deck "${deckId}" missing numeric totalValue`);
+    }
+    if (typeof d.cardCount !== 'number') {
+      throw new Error(`Invalid price data: deck "${deckId}" missing numeric cardCount`);
+    }
+    if (!Array.isArray(d.cards)) {
+      throw new Error(`Invalid price data: deck "${deckId}" missing cards array`);
+    }
+  }
+
+  return data as PriceDataShape;
+}
+
+export function validateLowestListings(data: unknown): LowestListingsData {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('Invalid lowest listings: expected an object');
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.updatedAt !== 'string') {
+    throw new Error('Invalid lowest listings: missing "updatedAt" string');
+  }
+  if (typeof obj.cards !== 'object' || obj.cards === null || Array.isArray(obj.cards)) {
+    throw new Error('Invalid lowest listings: missing "cards" object');
+  }
+
+  return data as LowestListingsData;
+}

--- a/tests/scripts/validate-input.test.ts
+++ b/tests/scripts/validate-input.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { validateDecklists, validatePriceData, validateLowestListings } from '../../scripts/validate-input';
+
+describe('validateDecklists', () => {
+  it('accepts valid decklists', () => {
+    const data = {
+      'deck-1': [{ name: 'Sol Ring', quantity: 1 }],
+      'deck-2': [{ name: 'Command Tower', quantity: 1, isCommander: false }],
+    };
+    expect(validateDecklists(data)).toEqual(data);
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateDecklists(null)).toThrow('expected an object');
+    expect(() => validateDecklists([])).toThrow('expected an object');
+    expect(() => validateDecklists('string')).toThrow('expected an object');
+  });
+
+  it('rejects deck that is not an array', () => {
+    expect(() => validateDecklists({ 'deck-1': 'not-array' })).toThrow('is not an array');
+  });
+
+  it('rejects card missing name', () => {
+    expect(() => validateDecklists({ 'deck-1': [{ quantity: 1 }] })).toThrow('missing name');
+  });
+
+  it('rejects card with empty name', () => {
+    expect(() => validateDecklists({ 'deck-1': [{ name: '', quantity: 1 }] })).toThrow('missing name');
+  });
+
+  it('rejects card with invalid quantity', () => {
+    expect(() => validateDecklists({ 'deck-1': [{ name: 'Sol Ring', quantity: 0 }] })).toThrow('invalid quantity');
+    expect(() => validateDecklists({ 'deck-1': [{ name: 'Sol Ring', quantity: -1 }] })).toThrow('invalid quantity');
+  });
+});
+
+describe('validatePriceData', () => {
+  it('accepts valid price data', () => {
+    const data = {
+      updatedAt: '2026-01-24T00:00:00.000Z',
+      decks: {
+        'deck-1': { totalValue: 100, cardCount: 100, cards: [] },
+      },
+    };
+    expect(validatePriceData(data)).toEqual(data);
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validatePriceData(null)).toThrow('expected an object');
+  });
+
+  it('rejects missing updatedAt', () => {
+    expect(() => validatePriceData({ decks: {} })).toThrow('missing "updatedAt"');
+  });
+
+  it('rejects missing decks', () => {
+    expect(() => validatePriceData({ updatedAt: '2026-01-24' })).toThrow('missing "decks" object');
+  });
+
+  it('rejects deck missing totalValue', () => {
+    expect(() => validatePriceData({
+      updatedAt: '2026-01-24',
+      decks: { 'deck-1': { cardCount: 1, cards: [] } },
+    })).toThrow('missing numeric totalValue');
+  });
+
+  it('rejects deck missing cardCount', () => {
+    expect(() => validatePriceData({
+      updatedAt: '2026-01-24',
+      decks: { 'deck-1': { totalValue: 100, cards: [] } },
+    })).toThrow('missing numeric cardCount');
+  });
+
+  it('rejects deck missing cards array', () => {
+    expect(() => validatePriceData({
+      updatedAt: '2026-01-24',
+      decks: { 'deck-1': { totalValue: 100, cardCount: 1 } },
+    })).toThrow('missing cards array');
+  });
+});
+
+describe('validateLowestListings', () => {
+  it('accepts valid lowest listings', () => {
+    const data = {
+      updatedAt: '2026-01-24T00:00:00.000Z',
+      cards: { 'Sol Ring': { name: 'Sol Ring', lowestListing: 1.5 } },
+    };
+    expect(validateLowestListings(data)).toEqual(data);
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateLowestListings(null)).toThrow('expected an object');
+  });
+
+  it('rejects missing updatedAt', () => {
+    expect(() => validateLowestListings({ cards: {} })).toThrow('missing "updatedAt"');
+  });
+
+  it('rejects missing cards object', () => {
+    expect(() => validateLowestListings({ updatedAt: '2026-01-24' })).toThrow('missing "cards" object');
+  });
+});


### PR DESCRIPTION
## Summary
- Add runtime validation for JSON inputs in `update-prices.ts` and `fetch-lowest-listings.ts`
- Validate decklists, price data, and lowest-listings structure before processing
- Fail fast with descriptive errors on malformed input
- Uses lightweight type guards (no new dependencies)

## Test plan
- [x] Unit tests for all validators (17 tests passing)
- [x] Lint clean on new files

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)