### PR TITLE
feat: create backup before overwriting price data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ dist-ssr
 package-lock.json
 pnpm-lock.yaml
 
+# Price data backups
+public/data/prices.*.json
+
 # Environment files
 .env
 .env.local

--- a/scripts/update-prices.ts
+++ b/scripts/update-prices.ts
@@ -9,7 +9,7 @@
  * For lowest listing data, run: bun scripts/fetch-lowest-listings.ts
  */
 
-import { writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { writeFileSync, readFileSync, mkdirSync, existsSync, copyFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import type { Decklists, CardPrices } from '../types';
@@ -348,6 +348,14 @@ async function main(): Promise<void> {
     };
 
     mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+
+    if (existsSync(OUTPUT_PATH)) {
+      const date = new Date().toISOString().split('T')[0];
+      const backupPath = OUTPUT_PATH.replace('.json', `.${date}.json`);
+      copyFileSync(OUTPUT_PATH, backupPath);
+      console.log(`Backed up existing prices to ${backupPath}`);
+    }
+
     writeFileSync(OUTPUT_PATH, JSON.stringify(output, null, 2));
 
     console.log(`\nWrote prices to ${OUTPUT_PATH}`);


### PR DESCRIPTION
## Summary
- Back up existing `prices.json` to `prices.YYYY-MM-DD.json` before writing new data
- Prevents data loss on failed or interrupted writes
- Backup files are gitignored

## Test plan
- [x] Lint clean
- [x] Backup only created when existing file exists
- [x] Timestamped filename format correct

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)