### PR TITLE
build: add TypeScript type-check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun lint
+      - run: bun typecheck


### PR DESCRIPTION
## Summary
- Add CI workflow that runs `bun lint` and `bun typecheck` on PRs and pushes to main
- Uses `tsc --noEmit` (already in package.json as `typecheck` script)

## Test plan
- [x] YAML valid (pre-commit check-yaml passes)
- [x] `typecheck` script exists in package.json

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)