### PR TITLE
feat: add URL state persistence for filters

### DIFF
--- a/components/DeckComparisonTable.tsx
+++ b/components/DeckComparisonTable.tsx
@@ -48,6 +48,8 @@ interface DeckComparisonTableProps {
   loadingDeck: string | null;
   onLoadPrice: (deck: PreconDeck) => void;
   onRefreshPrice: (deck: PreconDeck) => void;
+  filter: FilterState;
+  onFilterChange: (filter: Partial<FilterState>) => void;
 }
 
 export default function DeckComparisonTable({
@@ -56,9 +58,10 @@ export default function DeckComparisonTable({
   loadingDeck,
   onLoadPrice,
   onRefreshPrice,
+  filter,
+  onFilterChange,
 }: DeckComparisonTableProps) {
   const [sort, setSort] = useState<SortState>({ key: 'distroRoi', direction: 'desc' });
-  const [filter, setFilter] = useState<FilterState>({ year: 'all', set: 'all', roiThreshold: 'all' });
 
   const years = useMemo(() => {
     const uniqueYears = [...new Set(decks.map(d => d.year))];
@@ -197,7 +200,7 @@ export default function DeckComparisonTable({
         <div className="flex items-center gap-3 flex-wrap w-full sm:w-auto">
           <select
             value={filter.year}
-            onChange={(e) => setFilter(prev => ({ ...prev, year: e.target.value }))}
+            onChange={(e) => onFilterChange({ year: e.target.value })}
             className="bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 min-h-[44px] text-white text-sm flex-1 sm:flex-none"
           >
             <option value="all">All Years</option>
@@ -208,7 +211,7 @@ export default function DeckComparisonTable({
 
           <select
             value={filter.set}
-            onChange={(e) => setFilter(prev => ({ ...prev, set: e.target.value }))}
+            onChange={(e) => onFilterChange({ set: e.target.value })}
             className="bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 min-h-[44px] text-white text-sm flex-1 sm:flex-none"
           >
             <option value="all">All Sets</option>
@@ -219,7 +222,7 @@ export default function DeckComparisonTable({
 
           <select
             value={filter.roiThreshold}
-            onChange={(e) => setFilter(prev => ({ ...prev, roiThreshold: e.target.value }))}
+            onChange={(e) => onFilterChange({ roiThreshold: e.target.value })}
             className="bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 min-h-[44px] text-white text-sm flex-1 sm:flex-none"
           >
             {ROI_FILTERS.map(opt => (

--- a/hooks/useUrlState.ts
+++ b/hooks/useUrlState.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+
+type ParamValue = string | number | null;
+
+interface UseUrlStateOptions<T extends Record<string, ParamValue>> {
+  defaults: T;
+  /** Called when URL params change (e.g., on initial load or browser navigation) */
+  onUrlChange?: (params: T) => void;
+}
+
+/**
+ * Bidirectional sync between React state and URL search params.
+ * Uses shallow routing to avoid page reloads.
+ */
+export function useUrlState<T extends Record<string, ParamValue>>({
+  defaults,
+  onUrlChange,
+}: UseUrlStateOptions<T>) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const isInitialMount = useRef(true);
+  const lastUrlRef = useRef<string>('');
+
+  // Parse URL params into typed object
+  const parseParams = useCallback((): T => {
+    const result = { ...defaults };
+
+    for (const key of Object.keys(defaults)) {
+      const urlValue = searchParams.get(key);
+      const defaultValue = defaults[key];
+
+      if (urlValue === null) {
+        (result as Record<string, ParamValue>)[key] = defaultValue;
+      } else if (typeof defaultValue === 'number') {
+        // Default is a number, so parse URL value as number
+        const parsed = parseInt(urlValue, 10);
+        (result as Record<string, ParamValue>)[key] = isNaN(parsed) ? defaultValue : parsed;
+      } else if (defaultValue === null && /^\d+$/.test(urlValue)) {
+        // Default is null but URL value looks like a number - parse it
+        (result as Record<string, ParamValue>)[key] = parseInt(urlValue, 10);
+      } else {
+        (result as Record<string, ParamValue>)[key] = urlValue;
+      }
+    }
+
+    return result;
+  }, [searchParams, defaults]);
+
+  // Call onUrlChange on initial mount and when URL changes via browser navigation
+  useEffect(() => {
+    const currentUrl = searchParams.toString();
+
+    if (isInitialMount.current || currentUrl !== lastUrlRef.current) {
+      isInitialMount.current = false;
+      lastUrlRef.current = currentUrl;
+      onUrlChange?.(parseParams());
+    }
+  }, [searchParams, parseParams, onUrlChange]);
+
+  // Update URL with new params (shallow routing)
+  const setParams = useCallback(
+    (updates: Partial<T>) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      for (const [key, value] of Object.entries(updates)) {
+        const defaultValue = defaults[key];
+
+        // Remove param if it matches default or is null/undefined
+        if (value === null || value === undefined || value === defaultValue) {
+          params.delete(key);
+        } else {
+          params.set(key, String(value));
+        }
+      }
+
+      const newUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+      lastUrlRef.current = params.toString();
+      router.push(newUrl, { scroll: false });
+    },
+    [searchParams, pathname, router, defaults]
+  );
+
+  return {
+    params: parseParams(),
+    setParams,
+  };
+}

--- a/tests/hooks/useUrlState.test.ts
+++ b/tests/hooks/useUrlState.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUrlState } from '@/hooks/useUrlState';
+
+// Mock Next.js navigation
+const mockPush = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/',
+}));
+
+describe('useUrlState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset search params
+    mockSearchParams.delete('year');
+    mockSearchParams.delete('set');
+    mockSearchParams.delete('deck');
+  });
+
+  it('returns defaults when URL has no params', () => {
+    const defaults = { year: null as number | null, set: null as string | null };
+    const onUrlChange = vi.fn();
+
+    renderHook(() => useUrlState({ defaults, onUrlChange }));
+
+    expect(onUrlChange).toHaveBeenCalledWith({ year: null, set: null });
+  });
+
+  it('parses string params from URL', () => {
+    mockSearchParams.set('set', 'Duskmourn');
+    const defaults = { set: null as string | null };
+    const onUrlChange = vi.fn();
+
+    renderHook(() => useUrlState({ defaults, onUrlChange }));
+
+    expect(onUrlChange).toHaveBeenCalledWith({ set: 'Duskmourn' });
+  });
+
+  it('parses number params from URL', () => {
+    mockSearchParams.set('year', '2024');
+    const defaults = { year: null as number | null };
+    const onUrlChange = vi.fn();
+
+    renderHook(() => useUrlState({ defaults, onUrlChange }));
+
+    expect(onUrlChange).toHaveBeenCalledWith({ year: 2024 });
+  });
+
+  it('uses default for invalid number params', () => {
+    mockSearchParams.set('year', 'invalid');
+    const defaults = { year: 2025 };
+    const onUrlChange = vi.fn();
+
+    renderHook(() => useUrlState({ defaults, onUrlChange }));
+
+    expect(onUrlChange).toHaveBeenCalledWith({ year: 2025 });
+  });
+
+  it('setParams updates URL with shallow routing', () => {
+    const defaults = { year: null as number | null, set: null as string | null };
+
+    const { result } = renderHook(() => useUrlState({ defaults }));
+
+    act(() => {
+      result.current.setParams({ year: 2024, set: 'DSK' });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/?year=2024&set=DSK', { scroll: false });
+  });
+
+  it('setParams removes params that match defaults', () => {
+    mockSearchParams.set('year', '2024');
+    const defaults = { year: null as number | null };
+
+    const { result } = renderHook(() => useUrlState({ defaults }));
+
+    act(() => {
+      result.current.setParams({ year: null });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/', { scroll: false });
+  });
+
+  it('setParams removes null values', () => {
+    mockSearchParams.set('set', 'Duskmourn');
+    const defaults = { set: 'all' };
+
+    const { result } = renderHook(() => useUrlState({ defaults }));
+
+    act(() => {
+      result.current.setParams({ set: null });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/', { scroll: false });
+  });
+
+  it('setParams keeps existing params when updating others', () => {
+    mockSearchParams.set('year', '2024');
+    const defaults = { year: null as number | null, set: null as string | null };
+
+    const { result } = renderHook(() => useUrlState({ defaults }));
+
+    act(() => {
+      result.current.setParams({ set: 'DSK' });
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/?year=2024&set=DSK', { scroll: false });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds bidirectional URL sync for filter state (year, set, deck)
- Home page and compare page now persist filter selections in URL
- Enables shareable/bookmarkable filtered views

Closes #52

## Test plan
- [x] Unit tests for useUrlState hook (8 tests passing)
- [ ] Manual: Change filters, verify URL updates
- [ ] Manual: Load URL with params, verify filters applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)