### PR TITLE
chore: bump lucide-react to 0.564.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mtg-roi-tool",
       "dependencies": {
         "@vercel/analytics": "^1.6.1",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^0.564.0",
         "next": "^16.1.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -649,7 +649,7 @@
 
     "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
-    "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+    "lucide-react": ["lucide-react@0.564.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^0.564.0",
     "next": "^16.1.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
## Why
Dependabot proposed `lucide-react@0.563.0`, but that release is missing the `dist/cjs/lucide-react.js` entrypoint and breaks Vitest (ENOENT / cannot find module).

This bumps to `0.564.0`, which restores a working test/build.

## Changes
- `lucide-react` -> `^0.564.0`
- Update `bun.lock` so CI `--frozen-lockfile` continues to work

## Testing
- `bun lint`
- `bun typecheck`
- `bun test:ci`